### PR TITLE
Update VETTrak Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ https://restapi.zambion.com/swagger/
 
 ### VETtrak
 
-https://help-vettrak.readytech.io/support/solutions/folders/51000191596
+https://readytech.io/what-we-do/education/products/vettrak/technical-information/api-documentation
 
 ## Security
 


### PR DESCRIPTION
This pull request updates the VETtrak API documentation link in the `README.md` to point to the official ReadyTech technical information page.

- Documentation update:
  * Changed the VETtrak API documentation link in `README.md` to the new ReadyTech technical information URL.